### PR TITLE
Clock Update :) 

### DIFF
--- a/web-app/frontend/src/components/pageContent/statsBox/elapsedTime.tsx
+++ b/web-app/frontend/src/components/pageContent/statsBox/elapsedTime.tsx
@@ -1,40 +1,41 @@
-import React, {useState, useEffect} from 'react';
+import React, { useState, useEffect, useCallback, useRef } from "react";
 
-interface ElapsedTimeProps {
-    collecting: boolean
+interface PropsTypes {
+  collecting: boolean;
 }
 
-interface ElapsedTimeState{
-    time: Date,
-    intervalId: NodeJS.Timeout | undefined | any
-}
+const ElapsedTime: React.FC<PropsTypes> = ({ collecting }: PropsTypes) => {
+  const time = useRef<Date>(new Date(new Date().setHours(0, 0, 0, 0)));
+  let intervalRef = useRef<NodeJS.Timeout | null | any>(null);
+  const [intervalCounter, setIntervalCounter] = useState<Number>(0);
 
-const ElapsedTime: React.FC<ElapsedTimeProps> = (props: ElapsedTimeProps) => {
+  const increaseTime = useCallback(() => {
+    time.current.setSeconds(Number(time.current.getSeconds()) + 1);
+    setIntervalCounter(time.current.getSeconds());
+  }, []);
 
-    const [state, setState] = useState<ElapsedTimeState>({
-        time: new Date(new Date().setHours(0,0,0,0)),
-        intervalId: undefined,
-    });
-
-    const increaseTime = () => {
-        state.time.setSeconds(Number(state.time.getSeconds()) + 1);
-        setState(state);
+  useEffect(() => {
+    if (collecting) {
+      time.current.setHours(0, 0, 0, 0);
+      setIntervalCounter(0);
+      intervalRef.current = setInterval(increaseTime, 1000);
+    } else {
+      clearInterval(intervalRef.current);
     }
+  }, [collecting, increaseTime]);
 
-    useEffect(() => {
-        if (props.collecting === true) {
-            state.time.setHours(0, 0, 0, 0);
-            state.intervalId = setInterval(increaseTime, 1000);
-        } else {
-            clearInterval(state.intervalId);
-        }
-    });
-    
-    return (
-        <div className="elapsed-time">
-            { state.time.getHours() }:{ state.time.getMinutes() }:{ state.time.getSeconds() }
-        </div>
-    );
+  useEffect(() => {
+    return () => {
+      clearInterval(intervalRef.current);
+    };
+  }, []);
+
+  return (
+    <div className="elapsed-time">
+      {time.current.getHours()}:{time.current.getMinutes()}:
+      {time.current.getSeconds()}
+    </div>
+  );
 };
 
 export default ElapsedTime;


### PR DESCRIPTION
This component had a very similar problem to the graph. We had a `state` object that had time, and intervalId, although whenever we modified it, we would modify the state object directly, instead of creating a new object. This would cause the `useState` hook to not recognize a new value for the object and wouldn't force a re-render. 

Since the `date` object is never going to change (referentially), I used a `useRef` for it. This makes it more clear to the reader that modifications to this variable won't cause re-renders. 

I used a `useRef` for the `setInterval` return value because this variable is just a tool for tearing down the `setInterval`  and shouldn't have any effect on the components state/re-renders. 

`useState` for `intervalCounter`. This is set to the seconds as the clock increases. So as seconds increase we get a re-render each time. Nice thing about only having one state variable is that re-renders become very predictable. 

The first `useEffect` is for starting the interval and resetting the clock. **NOTE the second parameter to the `useEffect` is the dependency array.** This ensures the function will re-run whenever `collecting` changes. I saw a couple `useEffects` that didn't have dependency arrays, this is bad practice as its almost never the desired behaviour. If it's only supposed to run once, then give it an empty array. Any questions on this one let me know!

The second `useEffect` ensures that the interval will get cleaned up on unmount. If you're not super familiar with how return functions on `useEffects` work gimme a shout and I can explain what's happening here :) 